### PR TITLE
Implement Travis-CI for server tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+  - "4.1.1"
+  - "node"
+before_install: npm install -g grunt-cli
+install: npm install
+before_script: grunt build

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,23 @@
+
+module.exports = function(grunt) {
+
+  grunt.initConfig({
+    "file-creator": {
+        "createConfigFile": {
+          "server/config.js": function(fs, fd, done) {
+            fs.writeSync(fd, 'module.exports.youtubeKey = \'AIzaSyDt--PPbkglY1iFAKdOaeV54HcPYSP-QxU\';');
+            done();
+          }
+        }
+      }
+  });
+
+  grunt.loadNpmTasks('grunt-file-creator');
+  ////////////////////////////////////////////////////
+  // Main grunt tasks
+  ////////////////////////////////////////////////////
+
+  grunt.registerTask('build', function(n) {
+    grunt.task.run([ 'file-creator:createConfigFile' ] );
+  });
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "server/server.js",
   "scripts": {
-    "test": "mocha serverTest.js"
+    "test": "mocha test/server/serverTest.js"
   },
   "author": "",
   "license": "ISC",
@@ -14,6 +14,9 @@
     "chai": "^3.3.0",
     "express": "^4.13.3",
     "express-session": "^1.11.3",
+    "grunt": "^0.4.5",
+    "grunt-cli": "^0.1.13",
+    "grunt-file-creator": "^0.1.3",
     "mocha": "^2.3.3",
     "moment": "^2.10.6",
     "mysql": "^2.9.0",

--- a/test/server/serverTest.js
+++ b/test/server/serverTest.js
@@ -1,5 +1,5 @@
 var expect = require('chai').expect;
-var app = require('./server/server.js');
+var app = require('../../server/server.js');
 var socketPort = 1337;
 var moment = require('moment');
 


### PR DESCRIPTION
-Added grunt to auto-create the .config file containing the Youtube API Key ('grunt build' from repo root)
-Configured Travis-CI hooks to npm install, grunt build and run mocha test for every push to 'csling' remote or the 'politicalpenguin' parent repo
-As of this pull request, the server tests are automatically run and pass with each push 