### PR TITLE
Fixed chat analysis being run on every cycle, fixed linting 

### DIFF
--- a/Client/socket.js
+++ b/Client/socket.js
@@ -1,11 +1,8 @@
- 
-
 glitch.factory('socket', function ($rootScope) {
    var socket;
    if (window.__karma__) {
      socket = io.connect(window.location.protocol + "//" + window.location.hostname + ":" + 1337);
-   }
-   else {
+   } else {
      socket = io.connect();
    }
   return {

--- a/server/server.js
+++ b/server/server.js
@@ -25,15 +25,15 @@ var chatMessages = [];
 var currentPlaylist = [];
 var lastSongInPlaylist = {};
 
+// Configuration variables
+module.exports.chatAnalysisTime = 250;
+module.exports.playlistAnalysisTime = 1000;
+module.exports.youtubeResults = 5;
+
 // Import all modules with our server functionality
 var socketHandler = require(__dirname + '/app/socketHandler.js');
 var playlistHandler = require(__dirname + '/app/playlistHandler.js');
 var chatHandler = require(__dirname + '/app/chatHandler.js');
-
-// Configuration variables
-module.exports.chatAnalysisTime = 2000;
-module.exports.playlistAnalysisTime = 1000;
-module.exports.youtubeResults = 5;
 
 // Starts Server
 var startServer = function () {


### PR DESCRIPTION
Minor changes:

- chat analysis was being run too frequently, changed to actually only run once every chat analysis period. Additionally lowered the chat analysis refresh period, because 2s was way too slow.
- Fixed linting on client/socket.js