### PR TITLE
Feat/playlist emission

### DIFF
--- a/server/app/chatHandler.js
+++ b/server/app/chatHandler.js
@@ -1,10 +1,10 @@
 var app = require(__dirname + '/../server.js');
 var youtube = require(__dirname + '/youtubeUtilities.js');
-var chatAnalysisTime = app.chatAnalysisTime;
+var chatAnalysisTime = app.emptyChatAnalysisTime;
 var lastChatIdx = -1;
 
 module.exports.analyzeChat = function () {
-  setInterval(function () {
+  var analyzeChat = function () {
     var chatMessages = app.getMessages();
     var bangs = [];
     for (var i = lastChatIdx + 1; i < chatMessages.length; i++) {
@@ -22,5 +22,14 @@ module.exports.analyzeChat = function () {
         app.addToPlaylist(results[0]);
       });
     }
-  }, chatAnalysisTime);
+
+    // Re-run the chat handler
+    if (app.getPlaylist().length <= 1) {
+      chatAnalysisTime = app.emptyChatAnalysisTime;
+    } else {
+      chatAnalysisTime = app.fullChatAnalysisTime;
+    }
+    setTimeout(analyzeChat, chatAnalysisTime);
+  };
+  setTimeout(analyzeChat, chatAnalysisTime);
 };

--- a/server/app/chatHandler.js
+++ b/server/app/chatHandler.js
@@ -32,7 +32,7 @@ module.exports.analyzeChat = function () {
 
     // Add the top-desired bang to the playlist and broadcast to clients
     if (topBang) {
-        youtube.fetchYoutubeResults(topBang, function (results) {
+        youtube.fetchYoutubeResults(topBang, function (err, results) {
         // Add the top result to our playlist
         app.addToPlaylist(results[0]);
         sockets.emitPlaylist();

--- a/server/app/chatHandler.js
+++ b/server/app/chatHandler.js
@@ -35,9 +35,9 @@ module.exports.analyzeChat = function () {
         youtube.fetchYoutubeResults(topBang, function (results) {
         // Add the top result to our playlist
         app.addToPlaylist(results[0]);
+        sockets.emitPlaylist();
       });
     }
-    sockets.emitPlaylist();
 
     // Re-run the chat handler
     if (app.getPlaylist().length <= 1) {

--- a/server/app/chatHandler.js
+++ b/server/app/chatHandler.js
@@ -1,5 +1,6 @@
 var app = require(__dirname + '/../server.js');
 var youtube = require(__dirname + '/youtubeUtilities.js');
+var sockets = require(__dirname + '/socketHandler.js');
 var chatAnalysisTime = app.emptyChatAnalysisTime;
 var lastChatIdx = -1;
 
@@ -29,13 +30,14 @@ module.exports.analyzeChat = function () {
       }
     }
 
-    // Add the top-desired bang to the playlist
+    // Add the top-desired bang to the playlist and broadcast to clients
     if (topBang) {
         youtube.fetchYoutubeResults(topBang, function (results) {
         // Add the top result to our playlist
         app.addToPlaylist(results[0]);
       });
     }
+    sockets.emitPlaylist();
 
     // Re-run the chat handler
     if (app.getPlaylist().length <= 1) {

--- a/server/app/chatHandler.js
+++ b/server/app/chatHandler.js
@@ -15,9 +15,23 @@ module.exports.analyzeChat = function () {
       lastChatIdx = i;
     }
 
-    // For each bang, use the Youtube Search API
+    // Calculate top-desired bang
+    var bangCounts = {};
     for (var j = 0; j < bangs.length; j++) {
-      youtube.fetchYoutubeResults(bangs[j], function (err, results) {
+      bangCounts[bangs[j]] = (bangCounts[bangs[j]] || 0) + 1;
+    }
+    var topBang = null;
+    var topBangCount = 0;
+    for (var bang in bangCounts) {
+      if (bangCounts[bang] > topBangCount) {
+        topBang = bang;
+        topBangCount = bangCounts[bang];
+      }
+    }
+
+    // Add the top-desired bang to the playlist
+    if (topBang) {
+        youtube.fetchYoutubeResults(topBang, function (results) {
         // Add the top result to our playlist
         app.addToPlaylist(results[0]);
       });

--- a/server/app/playlistHandler.js
+++ b/server/app/playlistHandler.js
@@ -55,6 +55,8 @@ var playSong = module.exports.playSong = function (playlistEntry, callback) {
       time: 0
     });
 
+    socketHandler.emitPlaylist();
+
     if (callback) {
       callback();
     }

--- a/server/app/playlistHandler.js
+++ b/server/app/playlistHandler.js
@@ -55,8 +55,6 @@ var playSong = module.exports.playSong = function (playlistEntry, callback) {
       time: 0
     });
 
-    socketHandler.emitPlaylist();
-
     if (callback) {
       callback();
     }

--- a/server/app/socketHandler.js
+++ b/server/app/socketHandler.js
@@ -74,9 +74,8 @@ module.exports.emitPlaylist = function () {
 
       // Once we have retrieved information for every song, emit the playlist
       if (fetchedEntries === playlist.length) {
-        console.log(playlist);
         io.emit('playlist', {
-          playlist: playlist
+          playlist: playlistWithInfo
         });
       }
     }.bind(null, i));

--- a/server/app/socketHandler.js
+++ b/server/app/socketHandler.js
@@ -1,5 +1,6 @@
 var moment = require('moment');
 var app = require(__dirname + "/../server.js");
+var youtube = require(__dirname + "/youtubeUtilities.js");
 
 // Initializes io socket server
 // var ioPort = 1337;
@@ -53,7 +54,27 @@ module.exports.setUpSockets = function () {
 // Handles behaviors for all sockets
 module.exports.emitPlaylist = function () {
   var playlist = app.getPlaylist();
-  console.log(playlist);
+  for (var i = 0; i < playlist.length; i++) {
+    var parsedEntry = playlist[i].split('=');
+    youtube.getSongInfo(parsedEntry, function(object) {
+      console.log(object);
+      var contentDetails = object.items[0].contentDetails;
+      var snippet = object.items[0].snippet;
+
+      var videoDuration = moment.duration(contentDetails.duration);
+
+      var end = moment();
+      end.add(videoDuration);
+
+      var newSong = {};
+      newSong.id = parsedEntry[1];
+      newSong.url = playlistEntry;
+      newSong.title = snippet.title;
+      newSong.startMoment = moment();
+      newSong.endMoment = end;
+      console.log(newSong.title + ' is now playing.  Video will end ' + newSong.endMoment.calendar());
+    });
+  }
   io.emit('playlist', {
     playlist: playlist
   });

--- a/server/app/socketHandler.js
+++ b/server/app/socketHandler.js
@@ -56,7 +56,7 @@ module.exports.emitPlaylist = function () {
   var playlist = app.getPlaylist();
   for (var i = 0; i < playlist.length; i++) {
     var parsedEntry = playlist[i].split('=');
-    youtube.getSongInfo(parsedEntry, function(object) {
+    youtube.getSongInfo(parsedEntry, function (object) {
       console.log(object);
       var contentDetails = object.items[0].contentDetails;
       var snippet = object.items[0].snippet;

--- a/server/app/socketHandler.js
+++ b/server/app/socketHandler.js
@@ -51,7 +51,7 @@ module.exports.setUpSockets = function () {
   console.log('sockets established...');
 };
 
-// Handles behaviors for all sockets
+// Attaches song info to the playlist and emits it to client
 module.exports.emitPlaylist = function () {
   var playlist = app.getPlaylist();
   var fetchedEntries = 0;
@@ -59,6 +59,8 @@ module.exports.emitPlaylist = function () {
   for (var i = 0; i < playlist.length; i++) {
     var playlistEntry = playlist[i];
     var parsedEntry = playlistEntry.split('=');
+
+    // Retrieve song information for every song in the playlist
     youtube.getSongInfo(parsedEntry[1], function (position, err, result) {
       fetchedEntries++;
       var snippet = result.items[0].snippet;
@@ -69,6 +71,8 @@ module.exports.emitPlaylist = function () {
       newSong.title = snippet.title;
 
       playlistWithInfo[position] = newSong;
+
+      // Once we have retrieved information for every song, emit the playlist
       if (fetchedEntries === playlist.length) {
         console.log(playlist);
         io.emit('playlist', {

--- a/server/app/socketHandler.js
+++ b/server/app/socketHandler.js
@@ -61,7 +61,6 @@ module.exports.emitPlaylist = function () {
     var parsedEntry = playlistEntry.split('=');
     youtube.getSongInfo(parsedEntry[1], function (position, err, result) {
       fetchedEntries++;
-      var contentDetails = result.items[0].contentDetails;
       var snippet = result.items[0].snippet;
 
       var newSong = {};

--- a/server/app/socketHandler.js
+++ b/server/app/socketHandler.js
@@ -11,7 +11,7 @@ console.log("Socket.io server listening");
 module.exports.activeSockets = [];
 module.exports.numActiveClients = 0;
 
-// Handles all socket behavior
+// Handles all behavior specific to a given socket
 module.exports.setUpSockets = function () {
   io.on('connection', function (socket) {
     module.exports.activeSockets.push(socket);
@@ -48,4 +48,13 @@ module.exports.setUpSockets = function () {
     });
   });
   console.log('sockets established...');
+};
+
+// Handles behaviors for all sockets
+module.exports.emitPlaylist = function () {
+  var playlist = app.getPlaylist();
+  console.log(playlist);
+  io.emit('playlist', {
+    playlist: playlist
+  });
 };

--- a/server/server.js
+++ b/server/server.js
@@ -26,7 +26,8 @@ var currentPlaylist = [];
 var lastSongInPlaylist = {};
 
 // Configuration variables
-module.exports.chatAnalysisTime = 250;
+module.exports.emptyChatAnalysisTime = 250;
+module.exports.fullChatAnalysisTime = 15000;
 module.exports.playlistAnalysisTime = 1000;
 module.exports.youtubeResults = 5;
 

--- a/server/server.js
+++ b/server/server.js
@@ -27,7 +27,7 @@ var lastSongInPlaylist = {};
 
 // Configuration variables
 module.exports.emptyChatAnalysisTime = 250;
-module.exports.fullChatAnalysisTime = 15000;
+module.exports.fullChatAnalysisTime = 10000;
 module.exports.playlistAnalysisTime = 1000;
 module.exports.youtubeResults = 5;
 


### PR DESCRIPTION
Bunch of changes:

1) Chat analysis time is now variable, based on the number of songs in the playlist. If the playlist is near empty, refreshes frequently, otherwise slowly
2) The chat handler now adds the top-voted song (or bang) to the playlist once every chat duration
3) The server now emits the playlist to the clients once every chat-duration (assuming there was a change to the playlist).
4) The emitted playlist has all song details (fetched from Youtube) attached for easy display on client-side.

STILL TODO: handling "special" bangs, e.g. !next